### PR TITLE
Add img size auto scale to screen

### DIFF
--- a/colorsheet.css
+++ b/colorsheet.css
@@ -191,3 +191,8 @@ div.indent {
 div.indent2{
     text-indent: 50px;
 }
+img {
+    max-width: 100%;
+    height: auto;
+    width: auto;
+}

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
     <main>
         <img src="https://img.freepik.com/premium-vector/meeting-office-interior-business-conference-room-with-people-managers-working-team-cartoon-interior_80590-7766.jpg?w=1480" 
              alt="Meeting Minutes"
-             width="800"
         >
         <div class="box-meeting-info">
         <section>


### PR DESCRIPTION
Add img size auto scale to screen.
img tag now scale to windows screen unless width and height are specified by developer.